### PR TITLE
Fix #357.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ RUN go install -v github.com/google/cayley/cmd/cayley
 # Expose the port and volume for configuration and data persistence. If you're
 # using a backend like bolt, make sure the file is saved to this directory.
 VOLUME ["/data"]
-EXPOSE 64321
+EXPOSE 64210
 
-CMD ["cayley", "http", "-config", "/data/cayley.cfg", "-init"]
+CMD ["cayley", "http", "-config", "/data/cayley.cfg", "--host","0.0.0.0", "-init"]

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ To run the container one must first setup a data directory that contains the con
 ```
 mkdir data
 cp my_config.cfg data/cayley.cfg
-docker run -v $PWD/data:/data -p 64321:64321 -d quay.io/barakmich/cayley
+docker run -v $PWD/data:/data -p 127.0.0.1:64210:64210 -d quay.io/barakmich/cayley
 ```
 
 ## Disclaimer


### PR DESCRIPTION
Fix incorrect port in Dockerfile and README.md
Bind to all interfaces in Dockerfile run command.
Restrict binding to localhost in README docker run.